### PR TITLE
Implements log_det functions for arma, blaze and eigen using cholesky decomposition

### DIFF
--- a/include/dens/dmvnorm.ipp
+++ b/include/dens/dmvnorm.ipp
@@ -35,10 +35,22 @@ dmvnorm(const mT& X, const mT& mu_par, const mT& Sigma_par, bool log_form)
     const mT X_cent = X - mu_par; // avoids issues like Mat vs eGlue in templates
     const mT quadratic_term = mat_ops::trans(X_cent) * mat_ops::inv(Sigma_par) * (X_cent);
 
-    eT ret = cons_term - eT(0.5) * ( std::log(mat_ops::det(Sigma_par)) + quadratic_term(0,0) );
+    // eT ret = cons_term - eT(0.5) * ( std::log(mat_ops::det(Sigma_par)) + quadratic_term(0,0) );
+
+    // if (!log_form) {
+    //     ret = std::exp(ret);
+    // }
+
+    /*Safely Compute Logdeterminant using cholesky decomposition*/
+    eT logDetSigma = mat_ops::logDet(Sigma_par); 
+    
+    eT ret = cons_term - eT(0.5) * ( logDetSigma + quadratic_term(0,0) );
 
     if (!log_form) {
         ret = std::exp(ret);
+        /*Handle overflow*/
+        if(std::isinf(ret))
+            ret = std::numeric_limits<eT>::max();
     }
 
     //

--- a/include/misc/matrix_ops.hpp
+++ b/include/misc/matrix_ops.hpp
@@ -21,7 +21,6 @@
 /*
  * for internal use only; used to switch between the different matrix libraries
  */
-
 #ifdef STATS_WITH_MATRIX_LIB
 namespace mat_ops {
 
@@ -759,7 +758,8 @@ statslib_inline
 T
 logDet(const ArmaMat<T>& X)
 {
-    ArmaMat<T> vec = mat_ops::chol(X).diag().for_each([](T& val){ val = 2.0 * std::log(val);});
+    ArmaMat<T> vec = mat_ops::chol(X).diag();
+    vec.for_each([](T& val){ val = 2.0 * std::log(val);});
     return arma::as_scalar(arma::accu(vec));
 }
 #endif
@@ -770,10 +770,14 @@ statslib_inline
 Ta
 logDet(const BlazeMat<Ta,Tb>& X)
 {
-    
-    BlazeMat<Ta,Tb> vec1 = blaze::diagonal(mat_ops::chol(X)); //Diagonal of L
-    BlazeMat<Ta,Tb> vec2 = blaze::map( vec1, [](Ta val){ return 2.0 * std::log(val); } );
-    return blaze::sum(vec2);
+    BlazeMat<Ta,Tb> chol_sig = mat_ops::chol(X);
+    auto vec = blaze::diagonal(chol_sig); //Diagonal of L
+    Ta total = 0.0;
+    for(auto it=vec.cbegin(); it!=vec.cend(); ++it )
+    {
+        total += 2.0 * std::log(*it);
+    }
+    return total;
 }
 #endif
 

--- a/include/misc/matrix_ops.hpp
+++ b/include/misc/matrix_ops.hpp
@@ -749,5 +749,43 @@ var(const EigMat<Ta,iTr,iTc>& X)
 }
 #endif
 
+//
+
+// log of determinant
+
+#ifdef STATS_USE_ARMA
+template<typename T>
+statslib_inline
+T
+logDet(const ArmaMat<T>& X)
+{
+    ArmaMat<T> vec = mat_ops::chol(X).diag().for_each([](T& val){ val = 2.0 * std::log(val);});
+    return arma::as_scalar(arma::accu(vec));
+}
+#endif
+
+#ifdef STATS_USE_BLAZE
+template<typename Ta, bool Tb>
+statslib_inline
+Ta
+logDet(const BlazeMat<Ta,Tb>& X)
+{
+    
+    BlazeMat<Ta,Tb> vec1 = blaze::diagonal(mat_ops::chol(X)); //Diagonal of L
+    BlazeMat<Ta,Tb> vec2 = blaze::map( vec1, [](Ta val){ return 2.0 * std::log(val); } );
+    return blaze::sum(vec2);
+}
+#endif
+
+#ifdef STATS_USE_EIGEN
+template<typename Ta, int iTr, int iTc>
+statslib_inline
+Ta
+logDet(const EigMat<Ta,iTr,iTc>& X)
+{
+    return (mat_ops::chol(X).diagonal().array().log()*2.0).sum();
+}
+#endif
+
 } // namespace mat_ops
 #endif


### PR DESCRIPTION
I have implemented the functions to compute log_determinant using cholesky decomposition inside ```matrix_ops.hpp``` and used the same in ```dmvnormal.hpp``` to avoid direct computation of determinant as it breaks (underflows) in case of large covariance matrices. Also I tested the consistency of the results with all the three matrix libraries.