### PR TITLE
Typos

### DIFF
--- a/include/stats_incl/rand/rpois.hpp
+++ b/include/stats_incl/rand/rpois.hpp
@@ -45,7 +45,7 @@ rpois(const T rate_par, const ullint_t seed_val = std::random_device{}());
 template<typename mT, typename T1>
 statslib_inline
 mT
-rexp(const ullint_t n, const ullint_t k, const T1 rate_par);
+rpois(const ullint_t n, const ullint_t k, const T1 rate_par);
 #endif
 
 //

--- a/include/stats_incl/rand/rt.hpp
+++ b/include/stats_incl/rand/rt.hpp
@@ -45,7 +45,7 @@ rt(const T dof_par, const ullint_t seed_val = std::random_device{}());
 template<typename mT, typename T1>
 statslib_inline
 mT
-rchisq(const ullint_t n, const ullint_t k, const T1 dof_par);
+rt(const ullint_t n, const ullint_t k, const T1 dof_par);
 #endif
 
 //

--- a/include/stats_incl/rand/rt.ipp
+++ b/include/stats_incl/rand/rt.ipp
@@ -41,7 +41,7 @@ rt_compute(const T dof_par, rand_engine_t& engine)
 
     T numer = rnorm(T(0),T(1),engine);
     
-    return numer / std::sqrt( rt(dof_par,engine) / dof_par );
+    return numer / std::sqrt( rchisq(dof_par,engine) / dof_par );
 }
 
 }


### PR DESCRIPTION
Thanks for providing this package! In the middle of wrapping up a python binding (https://github.com/aforren1/pystatslib), I noticed these few function names didn't match, and the `rt` implementation was recursively calling itself rather than `rchisq`, leading to segfaults. Tests pass locally (Travis is pointed at the master branch?).