### PR TITLE
Add a global stats::random_engine_t.

### DIFF
--- a/include/stats_incl/misc/statslib_options.hpp
+++ b/include/stats_incl/misc/statslib_options.hpp
@@ -69,6 +69,16 @@ namespace stats
 
     using rand_engine_t = std::mt19937_64;
 
+	static struct default_engine_t {
+		void seed(const ullint_t seed_val=1776) { get_engine() = rand_engine_t(seed_val); }
+		operator rand_engine_t&() { return get_engine(); } 
+		private:
+			rand_engine_t& get_engine() {
+				static rand_engine_t engine(std::random_device{}());
+				return engine;
+			}
+	} default_engine;
+
     namespace GCINT = gcem::internal;
 
     template<class T>

--- a/include/stats_incl/rand/rinvwish.ipp
+++ b/include/stats_incl/rand/rinvwish.ipp
@@ -49,7 +49,7 @@ rinvwish(const mT& Psi_par, const pT nu_par, const bool pre_inv_chol)
 
     //
 
-    rand_engine_t engine(std::random_device{}());
+    rand_engine_t& engine = stats::default_engine;
 
     mT A;
     mat_ops::zeros(A,K,K);

--- a/include/stats_incl/rand/rnorm.ipp
+++ b/include/stats_incl/rand/rnorm.ipp
@@ -98,8 +98,7 @@ statslib_inline
 common_return_t<T1,T2>
 rnorm(const T1 mu_par, const T2 sigma_par, const ullint_t seed_val)
 {
-    rand_engine_t engine(seed_val);
-    return rnorm(mu_par,sigma_par,engine);
+    return rnorm(mu_par,sigma_par,stats::default_engine);
 }
 
 /**


### PR DESCRIPTION
This commit enables setting an explicit random number seed globally.  This is useful when using the vectorized wrappers which do not otherwise support setting a seed.  This commit is tested only with Blaze.

There are many possible ways add support for seeding the vector wrappers, and this pattern seemed the simplest to me.  It is not the first pattern attempted.  I do not really expect you to merge this as is, but maybe just think about and describe the correct, idiomatic way to possibly support this feature.  I don't mind actually doing the work on it, if you give me the guidance of how you want it done.  It would also be better if all the distributions were ported to the favored pattern; this commit only experimented with `rnorm` and `rinvwish`.